### PR TITLE
Move checkbox tokens from foundations to component

### DIFF
--- a/src/Checkbox/Tokens/tokens.ts
+++ b/src/Checkbox/Tokens/tokens.ts
@@ -1,0 +1,37 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  border: {
+    color: {
+      active: inube.palette.neutral.N80,
+      indeterminate: inube.palette.neutralAlpha.N0A,
+      checked: inube.palette.neutralAlpha.N0A,
+      invalid: inube.palette.red.R400,
+      disabled: inube.palette.neutral.N40,
+    },
+  },
+  background: {
+    color: {
+      active: inube.palette.neutral.N0,
+      indeterminate: inube.palette.blue.B400,
+      checked: inube.palette.blue.B400,
+      invalid: inube.palette.blue.B400,
+      disabled: inube.palette.neutral.N20,
+    },
+  },
+  vector: {
+    color: {
+      indeterminate: inube.palette.neutral.N0,
+      checked: inube.palette.neutral.N0,
+      invalid: inube.palette.neutral.N0,
+      disabled: inube.palette.neutral.N60,
+    },
+  },
+  outline: {
+    color: {
+      hover: inube.palette.blue.B300,
+    },
+  },
+};
+
+export { tokens };

--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -8,9 +8,9 @@ import {
   StyledPreventSelectableLabel,
   StyledSpan,
 } from "./styles";
-import { inube } from "@inubekit/foundations";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
+import { tokens } from "./Tokens/tokens";
 
 interface ICheckbox {
   id: string;
@@ -37,16 +37,14 @@ const Checkbox = (props: ICheckbox) => {
     onChange,
   } = props;
 
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { checkbox: typeof tokens };
   const disabledAppearance =
-    theme?.checkbox?.vector?.color?.disabled ||
-    inube.checkbox.vector.color.disabled;
+    theme?.checkbox?.vector?.color?.disabled || tokens.vector.color.disabled;
   const indeterminateAppearance =
     theme?.checkbox?.vector?.color?.indeterminate ||
-    inube.checkbox.vector.color.indeterminate;
+    tokens.vector.color.indeterminate;
   const checkedAppearance =
-    theme?.checkbox?.vector?.color?.checked ||
-    inube.checkbox.vector.color.checked;
+    theme?.checkbox?.vector?.color?.checked || tokens.vector.color.checked;
 
   return (
     <Stack direction="row" alignItems="center" gap="10px" width="fit-content">

--- a/src/Checkbox/styles.js
+++ b/src/Checkbox/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledCheckbox = styled.input`
   opacity: 0;
@@ -8,28 +8,25 @@ const StyledCheckbox = styled.input`
 
   &:checked + span {
     border-color: ${({ theme }) =>
-      theme?.checkbox?.border?.color?.checked ||
-      inube.checkbox.border.color.checked};
+      theme?.checkbox?.border?.color?.checked || tokens.border.color.checked};
     background-color: ${({ theme }) =>
       theme?.checkbox?.background?.color?.checked ||
-      inube.checkbox.background.color.checked};
+      tokens.background.color.checked};
   }
 
   &:focus + span {
     outline: 2px solid
       ${({ theme }) =>
-        theme?.checkbox?.vector?.color?.hover ||
-        inube.checkbox.vector.color.hover};
+        theme?.checkbox?.outline?.color?.hover || tokens.outline.color.hover};
     outline-offset: 2px;
   }
 
   &:disabled + span {
     border-color: ${({ theme }) =>
-      theme?.checkbox?.border?.color?.disabled ||
-      inube.checkbox.border.color.disabled};
+      theme?.checkbox?.border?.color?.disabled || tokens.border.color.disabled};
     background-color: ${({ theme }) =>
       theme?.checkbox?.background?.color?.disabled ||
-      inube.checkbox.background.color.disabled};
+      tokens.background.color.disabled};
   }
 `;
 
@@ -41,16 +38,14 @@ const StyledSpan = styled.span`
   border: 2px solid
     ${({ theme, checked, $indeterminate }) =>
       checked || $indeterminate
-        ? theme?.checkbox?.border?.color?.checked ||
-          inube.checkbox.border.color.checked
-        : theme?.checkbox?.border?.color?.active ||
-          inube.checkbox.border.color.active};
+        ? theme?.checkbox?.border?.color?.checked || tokens.border.color.checked
+        : theme?.checkbox?.border?.color?.active || tokens.border.color.active};
   background-color: ${({ theme, checked, $indeterminate }) =>
     checked || $indeterminate
       ? theme?.checkbox?.background?.color?.checked ||
-        inube.checkbox.background.color.checked
+        tokens.background.color.checked
       : theme?.checkbox?.background?.color?.active ||
-        inube.checkbox.background.color.active};
+        tokens.background.color.active};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
 
   display: flex;
@@ -60,8 +55,8 @@ const StyledSpan = styled.span`
   ${({ disabled }) =>
     disabled &&
     `
-    border-color: ${inube.checkbox.border.color.disabled};
-    background-color: ${inube.checkbox.background.color.disabled};
+    border-color: ${tokens.border.color.disabled};
+    background-color: ${tokens.background.color.disabled};
   `}
 `;
 


### PR DESCRIPTION
This PR moves the checkbox tokens from the foundations folder to the component folder, updating all necessary imports to match the new structure and ensuring that components are referencing the correct token paths. This change improves the organization, maintainability, and clarity of the token usage across the codebase.